### PR TITLE
CI: Change arduino-lint action from submit to update.

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -23,4 +23,4 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           project-type: library
-          library-manager: submit
+          library-manager: update


### PR DESCRIPTION
This has become necessary since the library has been now added to the library managers index.